### PR TITLE
Fix readme etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Qiitaの[アプリケーションページ](https://qiita.com/settings/applicati
   - コマンド: `export QIITA_ACCESS_TOKEN=1234567890abcdefg`
   - Qiitanageのコマンドで`-t`オプションを用いて指定する。
 - 半永続的な方法
-  - `export QIITA_ACCESS_TOKEN=1234567890abcdefg`と`.env`ファイルに記入します。`.env`ファイルは、人に見せてはならないものであるため`.gitignore`に必ず記入して下さい。
+  - `QIITA_ACCESS_TOKEN=1234567890abcdefg`と`.env`ファイルに記入します。`.env`ファイルは、人に見せてはならないものであるため`.gitignore`に必ず記入して下さい。
 
 ### 利用する
 

--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@ const usage_text = `
 Qiita記事を管理します。今は取得のみに対応しています。`
 
 program
-  .version('0.0.1')
+  .version('0.0.3')
   .usage(usage_text)
   .option('-a, --all-qiita', '全てのQiita記事をarticlesディレクトリに格納します。')
   .option('-i, --import-qiita <id>', '1つのQiita記事をarticlesディレクトリに格納します。')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qiitanage",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qiitanage",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qiitanage",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Qiitaの記事を管理します",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qiitanage",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Qiitaの記事を管理します",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "qiitanage": "./main.js"
   },
   "keywords": [
-    "qiita",
-    "zenn"
+    "Qiita",
+    "Zenn"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
- `.env`ファイルへのトークンの設定方法が誤っていたので、その修正。
- npmパッケージのkeywordsを、実際のサービス名に合わせて大文字始まりにした。

keywordsは、実際のサービス名と小文字だけの両方を用意すべきだったか？
それとも、片方だけで十分だったか。
気が向いたら、ちゃんと調べることにする。